### PR TITLE
core(CI): replace Travis in favour of Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,60 @@
+name: Lint
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  run-linters:
+    name: Run linters
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.5.0
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          registry-url: https://registry.npmjs.org
+
+      - name: Restore yarn cache if available
+        uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install dependencies
+        run: |
+          yarn install --frozen-lockfile
+
+      - name: Check prettier
+        run: |
+          yarn prettier:check
+        env:
+          CI: true
+
+      - name: Run tests
+        run: |
+          yarn test
+        env:
+          CI: true
+
+      - name: Run build
+        run: |
+          yarn build
+        env:
+          CI: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-sudo: false
-language: node_js
-node_js:
-- "stable"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # slate-instant-replace
 
-[![Build Status](https://travis-ci.org/enzoferey/slate-instant-replace.svg?branch=master)](https://travis-ci.org/enzoferey/slate-instant-replace)
+![Test CI](https://github.com/enzoferey/slate-instant-replace/actions/workflows/test.yml/badge.svg)
 
 A Slate plugin that gives you full power on the last word your user typed.
 
@@ -59,13 +59,13 @@ const plugins = [InstantReplace([YourFunction1, YourFunction2, YourFunction3])];
 
 Additionally this plugins exposes the follow [commands and queries](https://docs.slatejs.org/v/v0.47/guides/commands-and-queries) if you want to reuse them for your other plugins:
 
-| Name                    | Type      | Description                                                                       |
-| ----------------------- | --------- | --------------------------------------------------------------------------------- |
-| getSelection            | `query`   | Returns the current selection.                                                    |
-| getCurrentWordOffset    | `query`   | Returns the offset of the current word in the node.                               |
-| getLastWord             | `query`   | Returns the last word using as a reference the current anchor position.           |
-| getPreviousNode         | `query`   | Returns the previous node to the one currently focused.                           |
-| isFirstCharOfNode       | `query`   | Returns true if the anchor is at position 0 of the current node.                  |
+| Name                    | Type      | Description                                                                               |
+| ----------------------- | --------- | ----------------------------------------------------------------------------------------- |
+| getSelection            | `query`   | Returns the current selection.                                                            |
+| getCurrentWordOffset    | `query`   | Returns the offset of the current word in the node.                                       |
+| getLastWord             | `query`   | Returns the last word using as a reference the current anchor position.                   |
+| getPreviousNode         | `query`   | Returns the previous node to the one currently focused.                                   |
+| isFirstCharOfNode       | `query`   | Returns true if the anchor is at position 0 of the current node.                          |
 | focusPreviousInlineNode | `command` | Focuses the previous [`Inline`](https://docs.slatejs.org/v/v0.47/slate-core/inline) node. |
 
 Commands and queries get automatically attached to the `editor` instance. This means you can use them like this:

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "prepublishOnly": "npm run prettier && npm run build",
     "test": "jest",
     "test:watch": "jest --watch",
-    "prettier": "prettier --config \"./.prettierrc.js\" --write \"**/*.@(js|scss)\""
+    "prettier": "prettier --config \"./.prettierrc.js\" --write \"**/*.@(js|scss)\"",
+    "prettier:check": "prettier --check \"./.prettierrc.js\" --write \"**/*.@(js|scss)\""
   },
   "dependencies": {},
   "peerDependencies": {


### PR DESCRIPTION
Travis pivoted away from their org activities and open source a while ago. Instead of setting up there everything again, using Github Actions makes more sense now.